### PR TITLE
Remove query_all_packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 - [Installation Guide](https://pub.dev/packages/device_installed_apps#-installing-tab-)
 
+> [!WARNING]  
+> For Android 11 or later, you need to add ```<uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />``` permission in your **AndroidManifest.xml** file to Query **all** packages but this is restricted for Google Play, see more at [here](https://support.google.com/googleplay/android-developer/answer/10158779). If you don't add it, you can still use package but you don't get some system apps.
 ## Usage
 
 #### Device installed apps

--- a/README.md
+++ b/README.md
@@ -1,18 +1,13 @@
 # device_installed_apps
 
-A new Flutter plugin project.
-
-## Getting Started
-
 [Plugin](https://pub.dev/packages/device_installed_apps) for Flutter with methods related to device installed apps.
 
 | Supported platform  |
 | :-----:             |
 | Android             |
+## Getting Started
 
 - [Installation Guide](https://pub.dev/packages/device_installed_apps#-installing-tab-)
-
-## Installation Guide
 
 ## Usage
 
@@ -29,6 +24,7 @@ List<AppInfo> apps = await DeviceDeviceInstalledApps.getApps(
 
 ``` dart
 var permissions = ['android.permission.NFC','android.permission.ACCESS_FINE_LOCATION'];
+
 List<AppInfo> apps = await DeviceDeviceInstalledApps.getApps(includeSystemApps: true, permissions: permissions, bundleIdPrefix: 'com.hofinity', shouldHasAllPermissions: false);
 ```
 ---------

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.hofinity.device_installed_apps">
-    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
 </manifest>

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   fake_async:
     dependency: transitive
     description:
@@ -105,14 +105,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -125,18 +117,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -186,10 +178,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -234,10 +226,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   vector_math:
     dependency: transitive
     description:
@@ -250,10 +242,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f6deed8ed625c52864792459709183da231ebf66ff0cf09e69b573227c377efe
+      sha256: c620a6f783fa22436da68e42db7ebbf18b8c44b9a46ab911f666ff09ffd9153f
       url: "https://pub.dev"
     source: hosted
-    version: "11.3.0"
+    version: "11.7.1"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   webdriver:
     dependency: transitive
     description:
@@ -263,5 +263,5 @@ packages:
     source: hosted
     version: "3.0.2"
 sdks:
-  dart: ">=3.0.6 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.3.0"


### PR DESCRIPTION
- Updated dependencies for example app
- Updated readme.md and added instruction about query_all_packages permission
- Query_all_packages permission is removed because it is restricted for Google Play, developers can add this to their manifest file and i think using this permission is developer's decision.